### PR TITLE
Add safeguard merge for ElvUI_MerathilisUI settings

### DIFF
--- a/ElvUI_MerathilisUI/Init.lua
+++ b/ElvUI_MerathilisUI/Init.lua
@@ -233,7 +233,13 @@ end
 do
 	local checked = false
 	function MER:PLAYER_ENTERING_WORLD(_, isInitialLogin, isReloadingUi)
+		-- Runtime safeguard: on initial login ensure the mui DB subtree exists and defaults are merged.
+		-- This covers edge cases where load-order caused defaults not to be applied earlier.
 		if isInitialLogin then
+			if P and P.mui and E and E.db then
+				if not E.db.mui then E.db.mui = {} end
+				E:CopyTable(E.db.mui, P.mui)
+			end
 			self:AutoCopyPrivateProfile()
 			E:Delay(6, self.ChangelogReadAlert, self)
 			local icon = Engine[4].GetIconString([[Interface\AddOns\ElvUI_MerathilisUI\Media\Textures\pepeSmall]], 14)

--- a/ElvUI_MerathilisUI/Init.lua
+++ b/ElvUI_MerathilisUI/Init.lua
@@ -142,6 +142,13 @@ function MER:Initialize()
 	E.data:RegisterDefaults(E.DF)
 	E.charSettings:RegisterDefaults(E.privateVars)
 
+	-- Safeguard: ensure the mui DB subtree exists at runtime and merge defaults.
+	-- Some edge cases (load-order, LOD) can make defaults not present immediately; copy them explicitly.
+	if P and P.mui and E and E.db then
+		if not E.db.mui then E.db.mui = {} end
+		E:CopyTable(E.db.mui, P.mui)
+	end
+
 	if not self:CheckElvUIVersion() then
 		return
 	end


### PR DESCRIPTION
This pull request introduces a safeguard merge in the `Init.lua` file to ensure that the settings for `ElvUI_MerathilisUI` are reliably available at login. 

### Changes made:
- Added a safeguard merge immediately after re-registering defaults in the `MER:Initialize` function.
- The code checks if `E.db.mui` exists and merges it with `P.mui` defaults to prevent issues related to load order or load-on-demand scenarios.

### Benefits:
- This change reduces the likelihood of settings being unavailable at login due to timing issues with the initialization of the ElvUI database.
- Ensures that all expected keys are present in the runtime database, improving the reliability of the addon.

### Testing:
1. Reload the game or log in again after the change.
2. Check if `E.db.mui` is present in the chat output or by inspecting the SavedVariables file.
3. Enable Lua errors to catch any issues during initialization.

### Risks:
- The `E:CopyTable` function is specific to the ElvUI version in use; ensure compatibility with the current version.

### Next Steps:
- If desired, I can prepare a commit and pull request with this change, or we can discuss adding further runtime checks.