### PR TITLE
maps: optimize MiniMapCoords.lua — reduce redundant calls and fix coord change detection

### DIFF
--- a/ElvUI_MerathilisUI/Modules/Maps/MiniMapCoords.lua
+++ b/ElvUI_MerathilisUI/Modules/Maps/MiniMapCoords.lua
@@ -27,13 +27,17 @@ function module:UpdateCoords(_, elapsed)
 	end
 
 	if mapInfo.x and mapInfo.y then
-		if not F.AlmostEqual(mapInfo.x, self.mapInfoX) and not F.AlmostEqual(mapInfo.y, self.mapInfoY) then
+		local pcoords = self.coordsHolder and self.coordsHolder.playerCoords
+		if pcoords and ((not F.AlmostEqual(mapInfo.x, self.mapInfoX)) or (not F.AlmostEqual(mapInfo.y, self.mapInfoY))) then
 			self.mapInfoX = mapInfo.x
 			self.mapInfoY = mapInfo.y
-			self.coordsHolder.playerCoords:SetText(format(self.displayFormat, mapInfo.xText, mapInfo.yText))
+			pcoords:SetText(format(self.displayFormat, mapInfo.xText, mapInfo.yText))
 		end
 	else
-		self.coordsHolder.playerCoords:SetText("N/A")
+		local pcoords = self.coordsHolder and self.coordsHolder.playerCoords
+		if pcoords then
+			pcoords:SetText("N/A")
+		end
 	end
 
 	self.elapsed = 0
@@ -48,18 +52,17 @@ function module:CreateCoordsFrame()
 	self.coordsHolder = CreateFrame("Frame", "MER_CoordsHolder", Minimap)
 	self.coordsHolder:SetFrameLevel(Minimap:GetFrameLevel() + 10)
 	self.coordsHolder:SetFrameStrata(Minimap:GetFrameStrata())
-	self.coordsHolder:SetScript("OnUpdate", self.updateClosure)
 	E.FrameLocks[self.coordsHolder] = true
 
 	self.coordsHolder.playerCoords = self.coordsHolder:CreateFontString(nil, "OVERLAY")
 
-	_G.Minimap:HookScript("OnEnter", function()
+	Minimap:HookScript("OnEnter", function()
 		if not self.db.mouseOver or not self.db.enable or not E.private.general.minimap.enable then
 			return
 		end
 		self.coordsHolder:Show()
 	end)
-	_G.Minimap:HookScript("OnLeave", function()
+	Minimap:HookScript("OnLeave", function()
 		if not self.db.mouseOver or not self.db.enable or not E.private.general.minimap.enable then
 			return
 		end


### PR DESCRIPTION
This PR optimizes the MiniMapCoords module by reducing redundant calls and fixing a bug in coordinate change detection.

Changes:
- UpdateCoords: cache playerCoords locally to avoid repeated table lookups and null checks.
- Fix change detection: update when either X or Y changed (OR) instead of requiring both to change (AND).
- Remove premature SetScript("OnUpdate") in CreateCoordsFrame; OnUpdate is now only set when the module is enabled.
- Use local Minimap variable for HookScript calls instead of _G.Minimap.

Why:
- Fixes missed updates when only one coordinate changed.
- Reduces unnecessary work and avoids running OnUpdate before the module is enabled.

Testing notes:
- In-game verify coordinates update when moving (both X and/or Y changes), ensure N/A is shown in restricted areas, and that mouseover show/hide behavior of the coords remains correct.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>